### PR TITLE
Fix text formatting & remove #toTop button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,2 @@
 # OpenSUTD Landing Page
 This repository houses the prototype of [OpenSUTD](https://opensutd.org/)'s about page.
-
-## TODO
-- Add more content.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -195,32 +195,6 @@ html {
     color: #43485c;
 }
 
-#toTop {
-    height: 50px;
-    width: 50px;
-    display: none;
-    position: fixed;
-    bottom: 20px;
-    right: 30px;
-    z-index: 1000;
-    border: none;
-    outline: none;
-    background-color: rgba(255, 114, 111, 0.65);
-    color: white;
-    cursor: pointer;
-    border-radius: 50%;
-    font-size: 2rem;
-    box-shadow: 0 5px 20px rgba(255, 25, 80, 0.3);
-}
-
-#toTop a {
-    color: white;
-}
-
-#toTop:hover {
-    background-color: #5c4343;
-}
-
 ::-webkit-scrollbar {
     width: 8px;
     background-color: rgba(245, 245, 245, 0);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -32,16 +32,3 @@ $(document).on("click", 'a[href^="#"]', function(event) {
         500
     );
 });
-
-// When the user scrolls down 20px from the top of the document, show the scroll up button
-window.onscroll = function() {
-    scrollFunction();
-};
-
-function scrollFunction() {
-    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-        document.getElementById("toTop").style.display = "block";
-    } else {
-        document.getElementById("toTop").style.display = "none";
-    }
-}

--- a/index.html
+++ b/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <!-- Curious chap, aren't you? 👀 -->
-<html lang="en-US">
+<html lang="en-US" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no">
-        <meta name="description" content="Home of OpenSUTD" />
+        <meta name="description" property="og:description" content="Home of OpenSUTD" />
         <meta content="Home of OpenSUTD" />
         <meta content="OpenSUTD" property="og:title" /><meta content="Home of OpenSUTD" property="twitter:title" />
-
         <link rel="shortcut icon" href="images/opensutd.ico">
+        <meta property="og:image" content="images/opensutd.ico" />
         <title>OpenSUTD</title>
         <meta name="description" content="This is our story." />
         <!-- <link rel="stylesheet" href="assets/css/bulma.min.css" integrity="sha256-vK3UTo/8wHbaUn+dTQD0X6dzidqc5l7gczvH+Bnowwk=" crossorigin="anonymous" /> -->
@@ -21,13 +21,6 @@
         <script src="assets/js/gitgraph.js"></script> 
     </head>
     <body>
-        <!-- Scroll Up Button -->
-        <form action="#top">
-            <button id="toTop" title="Go to top">
-                <i class="fas fa-angle-up"></i>
-            </button>
-        </form>
-
         <!-- Header -->
         <div class="header-wrapper" id="top">
             <section class="hero is-large">
@@ -234,7 +227,7 @@
                             <h1 class="title has-text-centered name-title">Alexander Fonseca</h1>
                             <p class="seperator-text">Events</p>
                             <p>
-                                Loves presentations. Loves alcohol. Definitely presentations + alcohol (also guards houses)
+                                Loves presentations. Loves alcohol. Definitely presentations + alcohol. (Also guards houses.)
                             </p>
                             <br>
                             <div style="text-align: center">
@@ -286,7 +279,7 @@
                             <h1 class="title has-text-centered name-title">Chester Koh</h1>
                             <p class="seperator-text">Contributor</p>
                             <p>
-                                Yes he made an SUTD <a href="https://istdmc.opensutd.org/">Minecraft</a> server! Currently working on infosys+, cloud dev and memes
+                                Yes he made an SUTD <a href="https://istdmc.opensutd.org/">Minecraft</a> server! Currently working on infosys+, cloud dev and memes.
                             </p>
                             <br>
                             <div style="text-align: center">
@@ -300,7 +293,7 @@
                             <h1 class="title has-text-centered name-title">Caleb Foo</h1>
                             <p class="seperator-text">Contributor</p>
                             <p>
-                                In the midst of cooking up something for IAP'2020. Also, 3DC is now a Google Developer Club!
+                                In the midst of cooking up something for IAP 2020. Also, 3DC is now a Google Developer Club!
                             </p>
                             <br>
                             <div style="text-align: center">
@@ -390,7 +383,7 @@
                             <h1 class="title has-text-centered name-title">Dody Senputra</h1>
                             <p class="seperator-text">Contributor</p>
                             <p>
-                                Interested in product dev and robots, that's why he's in SOAR. Always open to collaborate if you want to create
+                                Interested in product dev and robots, that's why he's in SOAR. Always open to collaborate if you want to create.
                             </p>
                             <br>
                             <div style="text-align: center">


### PR DESCRIPTION
Reason for #toTop button removal is that it is unnecessary due to the presence of navbar and that its shape was distorted on mobile (for e.g. on iPhone 6).