### PR TITLE
Link course notes directly to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                         <div class="column is-3.5 resource-div" data-aos="fade-right">
                             <p class="title has-text-centered resource-title"><i class="fas fa-pencil-alt" style="color:#E81612"></i> Notes</p>
                             <ul style="margin-left:2em; list-style-type: circle;">
-                                <li><a href="https://github.com/OpenSUTD/course-notes" target="_blank">SUTD Course Notes</a></li>
+                                <li><a href="https://opensutd.org/course-notes/" target="_blank">SUTD Course Notes</a></li>
                                 <li><a href="https://github.com/OpenSUTD/coding-notes" target="_blank">methylDragon's Coding Notes</a></li>
                                 <li><a href="https://github.com/OpenSUTD/programming_notes" target="_blank">PengFei's Programming Notes</a></li>
                             </ul>


### PR DESCRIPTION
The link for course notes should lead directly to the main website rather than the Github repo